### PR TITLE
Potential fix for code scanning alert no. 25: Unused import

### DIFF
--- a/src/services/sync.py
+++ b/src/services/sync.py
@@ -4,7 +4,7 @@ Handles bidirectional sync and automatic reconnection.
 """
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, Any, Optional
 import threading
 import time


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/25](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/25)

The fix is to remove only the unused symbol from the import statement while keeping the used ones intact.

Best minimal fix in `src/services/sync.py`:
- Update line 7 import from:
  - `from datetime import datetime, timedelta`
- To:
  - `from datetime import datetime`

No functional behavior changes are required; this only removes an unnecessary dependency reference and resolves the static analysis warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
