### PR TITLE
Potential fix for code scanning alert no. 24: Unused import

### DIFF
--- a/src/services/sync.py
+++ b/src/services/sync.py
@@ -2,7 +2,6 @@
 Synchronization service for maintaining consistency between cache and Azure PostgreSQL.
 Handles bidirectional sync and automatic reconnection.
 """
-import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Dict, Any, Optional


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/24](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/24)

The correct fix is to remove the unused `asyncio` import from `src/services/sync.py` without changing any logic. This resolves the static analysis warning and improves readability by keeping only necessary dependencies.

Best single change:
- In `src/services/sync.py`, delete the line `import asyncio` at the top import section.
- No other code changes, imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
