### PR TITLE
Potential fix for code scanning alert no. 19: Unused import

### DIFF
--- a/src/services/cache.py
+++ b/src/services/cache.py
@@ -8,7 +8,6 @@ from datetime import datetime, date
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, asdict
 import threading
-import time
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/19](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/19)

To fix an unused import, remove the import statement for the unused module.

In `src/services/cache.py`, delete `import time` from the import block at the top of the file. No other code changes are needed, and functionality remains unchanged because the import is not used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
