### PR TITLE
Potential fix for code scanning alert no. 17: Unused import

### DIFF
--- a/src/services/cache.py
+++ b/src/services/cache.py
@@ -2,7 +2,6 @@
 High-availability caching service for lamp state management.
 Provides fallback when Azure PostgreSQL is unavailable and maintains state consistency.
 """
-import json
 import logging
 from datetime import datetime, date
 from typing import Dict, List, Optional, Any


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/17](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/17)

To fix an unused import, remove the import statement for the module that is never referenced.

In `src/services/cache.py`, update the import section at the top of the file and delete `import json` (line 5 in the snippet). No other code changes are required, and functionality remains unchanged because the import is not used in the provided code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
