### PR TITLE
Potential fix for code scanning alert no. 15: Unused import

### DIFF
--- a/src/api/routers.py
+++ b/src/api/routers.py
@@ -12,7 +12,6 @@ from database.ha_repository import HALampRepository
 from database.models import (
     LampActivityResponse,
     LampStatisticsResponse,
-    CurrentLampStateResponse,
     LampDashboardResponse
 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/15](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/15)

Remove `CurrentLampStateResponse` from the grouped import in `src/api/routers.py` and keep the remaining imported models unchanged.

Best fix (no functional change):
- Edit only the `from database.models import (...)` block near lines 12–17.
- Delete the `CurrentLampStateResponse` entry.
- Do not change any endpoint logic, signatures, or other imports.

This resolves the CodeQL warning while preserving behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
