### PR TITLE
Potential fix for code scanning alert no. 14: Unused import

### DIFF
--- a/src/database/repository.py
+++ b/src/database/repository.py
@@ -4,7 +4,6 @@ Repository pattern for database operations using psycopg2
 import logging
 from datetime import datetime, date, timedelta
 from typing import Optional, List
-import psycopg2
 from .models import LampActivity, LampStatistics, CurrentLampState
 from .models import LampActivityResponse, LampStatisticsResponse, CurrentLampStateResponse, LampDashboardResponse
 from .database import db_config


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/14](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/14)

The correct fix is to remove the unused `psycopg2` import from `src/database/repository.py`.

Best single fix without changing functionality:
- Edit the import section at the top of `src/database/repository.py`.
- Delete only `import psycopg2` (line 7 in the snippet).
- Keep all other imports unchanged.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
