### PR TITLE
Potential fix for code scanning alert no. 12: Unused import

### DIFF
--- a/src/database/database.py
+++ b/src/database/database.py
@@ -6,7 +6,7 @@ import logging
 import re
 import psycopg2
 import psycopg2.extras
-from typing import Optional, Dict, Any, List
+from typing import Dict, Any, List
 from contextlib import contextmanager
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/12](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/12)

To fix an unused import, remove only the unused symbol from the import list while keeping the actually used symbols intact.  
In `src/database/database.py`, update the typing import on line 9 by deleting `Optional` and leaving `Dict`, `Any`, and `List`. This avoids changing runtime functionality and resolves the CodeQL warning cleanly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
