### PR TITLE
Potential fix for code scanning alert no. 13: Unused import

### DIFF
--- a/src/database/repository.py
+++ b/src/database/repository.py
@@ -2,7 +2,7 @@
 Repository pattern for database operations using psycopg2
 """
 import logging
-from datetime import datetime, date, timedelta
+from datetime import datetime, date
 from typing import Optional, List
 import psycopg2
 from .models import LampActivity, LampStatistics, CurrentLampState


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/13](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/13)

To fix an unused import, remove only the unused symbol from the import list while keeping the rest unchanged.  
In `src/database/repository.py`, update the datetime import line to remove `timedelta` and retain `datetime` and `date` (since those may still be used elsewhere in the file, including hidden regions). This is the minimal, behavior-preserving change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
