### PR TITLE
Potential fix for code scanning alert no. 18: Unused import

### DIFF
--- a/src/services/cache.py
+++ b/src/services/cache.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import datetime, date
 from typing import Dict, List, Optional, Any
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 import threading
 import time
 


### PR DESCRIPTION
Potential fix for [https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/18](https://github.com/jaredthivener/python-lamp-web-app/security/code-scanning/18)

The correct fix is to remove only the unused symbol from the import statement, leaving all used imports intact.  
In `src/services/cache.py`, update the dataclasses import so it imports `dataclass` only.

- **File:** `src/services/cache.py`
- **Region:** top import block (line 9 in provided snippet)
- **Change:**  
  - From: `from dataclasses import dataclass, asdict`  
  - To: `from dataclasses import dataclass`
- No other code changes, methods, or new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
